### PR TITLE
Direct message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ The files in the `stat` folder are self-explanatory; they allow for learning int
 
 Log into [GroupMe's web interface](https://web.groupme.com/groups) and use Chrome or Safari's inspector to monitor the network requests when you load one of your groups.
 
-You'll notice a GET request to an endpoint `https://v2.groupme.com/groups/GROUP_ID/messages`.
+You'll notice a GET request to an endpoint `https://v2.groupme.com/groups/GROUP_ID/messages` for a group chat, or `https://api.groupme.com/v3/direct_messages?other_user_id=OTHER_USER_ID` for direct messages.
 
 One of the headers sent with that request, `X-Access-Token`, is your access token.
 
 ## Finding your group ID
 
-Again, in GroupMe's web interface, the group ID is the numeric ID included in the group's URL (`https://web.groupme.com/groups/GROUP_ID`).
+Again, in GroupMe's web interface, the group ID is the numeric ID included in the group's URL (`https://web.groupme.com/groups/GROUP_ID`). For direct messages, you'll need the other_user_id.
 
 ## Requirements/Dependencies/Python
 

--- a/html-transcript.py
+++ b/html-transcript.py
@@ -122,8 +122,8 @@ def write_html_transcript(messages, outfile, imgcache):
 def write_html(folder, messages, emoji=True):
     imgcache = ImageCache(folder)
     index_fn = os.path.join(folder, 'index.html')
-    shutil.copyfile('assets/groupme.css', os.path.join(folder, 'groupme.css'))
-    shutil.copyfile('assets/groupme.js', os.path.join(folder, 'groupme.js'))
+    shutil.copyfile(sys.path[0] + '/assets/groupme.css', os.path.join(folder, 'groupme.css'))
+    shutil.copyfile(sys.path[0] + '/assets/groupme.js', os.path.join(folder, 'groupme.js'))
     with open(index_fn, 'w') as f:
         f.write(_HTML_HEADER)
         write_html_transcript(messages, f, imgcache)

--- a/html-transcript.py
+++ b/html-transcript.py
@@ -79,10 +79,18 @@ def write_html_transcript(messages, outfile, imgcache):
         text = message[u'text']
         if text is None:
             text = u''
-        system = message[u'system']
+        system = message.get(u'system', None)
         faves = message[u'favorited_by']
         nlikes = faves if faves == 0 else len(faves)
-        pic = message[u'picture_url']
+        pic = message.get(u'picture_url', None)
+
+        # Picture is included as an attachment on direct messages.
+        # This might have to be rewritten if there are ever multiple images
+        # attached to a single message. Right now I've only seen multiple
+        # attachments for emoji.
+        if message.get(u'attachments', []) != []:
+            if message[u'attachments'][0].get(u'type', None) in ['image', 'linked_image']:
+                pic = message[u'attachments'][0][u'url']
 
 
         # Open div

--- a/simple-transcript.py
+++ b/simple-transcript.py
@@ -21,7 +21,7 @@ def printTranscript(messages, outputFilename):
             else:
                 text = "(no text)"
 
-            if message[u'system'] is True:
+            if message.get(u'system', None) is True:
                 system_padded = '(SYS) '
             else:
                 system_padded = ''
@@ -31,10 +31,12 @@ def printTranscript(messages, outputFilename):
             else:
                 favorites_padded = ''
 
-            if message[u'picture_url'] is not None:
+            pic = ''
+            if message.get(u'picture_url') is not None:
                 pic = ' ; photo URL ' + message[u'picture_url']
-            else:
-                pic = ''
+            elif message.get(u'attachments', []) != []:
+                if message[u'attachments'][0].get(u'type', None) in ['image', 'linked_image']:
+                    pic = ' ; photo URL ' + message[u'attachments'][0][u'url']
 
             line = u'{0}{1}({2}){3}: {4}{5}\n'.format(
                 system_padded, name, time, favorites_padded, text, pic


### PR DESCRIPTION
I added support for downloading a transcript of a direct message session, in addition to group chats. This is literally my first time touching Python, so it might be worth looking it over to make sure I didn't do anything stupid before you accept it, but it worked for me :)

I used .get and a default "None" value in a couple of places where the JSON structure for the direct message is different than for a group chat message, and added the direct message URL, handling of the way images are attached to DMs, and a --mode switch to allow passing in the other_user_id for DMs.